### PR TITLE
[Week 04 - DP] ASYMTILING 해결

### DIFF
--- a/week4-dp/rhksdlr134/ASYMTILING-rhksdlr134.java
+++ b/week4-dp/rhksdlr134/ASYMTILING-rhksdlr134.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+
+public class Asymtiling {
+    static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static final int MOD = 1000000007;
+
+    static int[] tileMemo = new int[101];
+
+    public static void main(String[] args) throws Exception {
+        initializeTiling();
+
+        Asymtiling main = new Asymtiling();
+
+        int C = Integer.parseInt(br.readLine());
+        while (C-- > 0) {
+            main.solve();
+        }
+
+        bw.close();
+        br.close();
+    }
+
+    private static void initializeTiling() {
+        Arrays.fill(tileMemo, -1);
+
+        tileMemo[0] = tileMemo[1] = 1;
+        tiling(100);
+    }
+
+    private static int tiling(int length) {
+        if (length <= 1 || tileMemo[length] != -1) {
+            return tileMemo[length];
+        }
+
+        return tileMemo[length] = (tiling(length - 2) + tiling(length - 1)) % MOD;
+    }
+
+    private void solve() throws Exception {
+        int n = Integer.parseInt(br.readLine());
+
+        bw.write(calculateAsymmetric(n) + "\n");
+    }
+
+    private int calculateAsymmetric(int length) {
+        int totalCnt = tileMemo[length];
+
+        totalCnt = (totalCnt - tileMemo[length / 2] + MOD) % MOD;
+
+        return length % 2 == 1
+                ? totalCnt
+                : (totalCnt - tileMemo[length / 2 - 1] + MOD) % MOD;
+    }
+
+}


### PR DESCRIPTION
문제의 핵심은 타일배치가 Palindrome 형태면 안된다는 조건이 붙어있다는 점이었습니다.

비대칭타일에 대한 규칙을 찾는 것보다, 전체 타일링 건수에서 대칭 타일의 개수를 제거하는 것이 수월할 것으로 판단하여 풀었습니다.